### PR TITLE
Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,18 +14,21 @@ jobs:
       - name: Set release version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}"
 
-      - name: Install
-        run: npm ci
-
-      - name: Setup test browser
-        uses: browser-actions/setup-chrome@latest
-
-      - name: Test
-        run: npm run test:ci
+#      - name: Install
+#        run: npm ci
+#
+#      - name: Setup test browser
+#        uses: browser-actions/setup-chrome@latest
+#
+#      - name: Test
+#        run: npm run test:ci
 
       - name: Update package version
         run: |
+          cd projects/gallery
           npm version ${RELEASE_VERSION}
+          git config user.name github-actions
+          git config user.email github-actions@github.com
           git add package.json
           git commit -m "Update version (automatic)"
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set release version
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}"
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Install
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         run: npm ci
 
       - name: Setup test browser
-        uses: browser-actions/setup-firefox@latest
+        uses: browser-actions/setup-chrome@latest
 
       - name: Test
         run: npm run test:ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,11 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Setup test browser
+        uses: browser-actions/setup-firefox@latest
+
       - name: Test
-        run: npm test
+        run: npm run test:ci
 
       - name: Update package version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      NPM_PUBLISH_EMAIL: ${{ secrets.NPM_PUBLISH_EMAIL }}
       NPM_PUBLISH_KEY: ${{ secrets.NPM_PUBLISH_KEY }}
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,26 +14,19 @@ jobs:
       - name: Set release version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}"
 
-#      - name: Install
-#        run: npm ci
-#
-#      - name: Setup test browser
-#        uses: browser-actions/setup-chrome@latest
-#
-#      - name: Test
-#        run: npm run test:ci
+      - name: Install
+        run: npm ci
+
+      - name: Setup test browser
+        uses: browser-actions/setup-chrome@latest
+
+      - name: Test
+        run: npm run test:ci
 
       - name: Update package version
         run: |
           cd projects/gallery
           npm version ${RELEASE_VERSION}
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add package.json
-          git commit -m "Update version (automatic)"
-          git push
-          git tag -f -a ${RELEASE_VERSION}
-          git push -f --tags
 
       - name: Build & Package
         run: |
@@ -43,6 +36,6 @@ jobs:
       - name: Release
         run: |
           cd dist/gallery
-          echo "publishing"
+          echo "publishing ${RELEASE_VERSION}"
 #          npm publish
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,5 @@ jobs:
       - name: Release
         run: |
           cd dist/gallery
-          echo "publishing ${RELEASE_VERSION}"
-#          npm publish
+          npm publish
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    env:
+      NPM_PUBLISH_EMAIL: ${{ secrets.NPM_PUBLISH_EMAIL }}
+      NPM_PUBLISH_KEY: ${{ secrets.NPM_PUBLISH_KEY }}
+
     steps:
       - uses: actions/checkout@v2
 
@@ -26,7 +30,7 @@ jobs:
       - name: Update package version
         run: |
           cd projects/gallery
-          npm version ${RELEASE_VERSION}
+          npm version --no-git-tag-version ${RELEASE_VERSION}
 
       - name: Build & Package
         run: |
@@ -35,6 +39,7 @@ jobs:
 
       - name: Release
         run: |
+          npm set //registry.npmjs.org/:_authToken $NPM_PUBLISH_KEY
           cd dist/gallery
           npm publish
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: build and deploy production
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+#      - name: Build
+#        run: |
+#          npm ci
+#          npm run build
+#
+#      - name: Test
+#        run: npm test
+
+      - name: Release
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: build and deploy production
+name: Release
 
 on:
   release:
@@ -9,18 +9,34 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v2
-        with:
-          persist-credentials: false
+      - uses: actions/checkout@v2
 
-#      - name: Build
-#        run: |
-#          npm ci
-#          npm run build
-#
-#      - name: Test
-#        run: npm test
+      - name: Set release version
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}"
+
+      - name: Install
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Update package version
+        run: |
+          npm version ${RELEASE_VERSION}
+          git add package.json
+          git commit -m "Update version (automatic)"
+          git push
+          git tag -f -a ${RELEASE_VERSION}
+          git push -f --tags
+
+      - name: Build & Package
+        run: |
+          npm run build
+          cat README.md > dist/gallery/README.md
 
       - name: Release
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}"
+        run: |
+          cd dist/gallery
+          echo "publishing"
+#          npm publish
+

--- a/package.json
+++ b/package.json
@@ -16,11 +16,9 @@
     "build": "ng build",
     "build:demo": "ng build --project=demo --prod --base-href /ngx-doe-gallery/",
     "test": "ng test --project=gallery",
-    "test:hdls": "npm test -- --browsers=ChromeHeadless",
     "test:demo": "ng test --project=demo",
     "test:ci": "npm test -- --watch=false --code-coverage",
     "lint": "ng lint",
-    "upload": "npm run build && cat README.md > dist/gallery/README.md && cd dist/gallery && npm publish",
     "e2e": "ng e2e"
   },
   "private": true,

--- a/projects/gallery/karma.conf.js
+++ b/projects/gallery/karma.conf.js
@@ -7,8 +7,8 @@ module.exports = function (config) {
     frameworks: ['jasmine', '@angular-devkit/build-angular'],
     plugins: [
       require('karma-jasmine'),
-      // require('karma-chrome-launcher'),
-      require('karma-firefox-launcher'),
+      require('karma-chrome-launcher'),
+      // require('karma-firefox-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
       require('@angular-devkit/build-angular/plugins/karma'),
@@ -28,18 +28,18 @@ module.exports = function (config) {
     autoWatch: true,
     usePolling: true,
     browsers: [
-      'TouchyFirefox',
-      // 'Chrome',
+      // 'TouchyFirefox',
+      'ChromeHeadless',
     ],
     singleRun: false,
     restartOnFileChange: true,
-    customLaunchers: {
-      TouchyFirefox: {
-        base: 'Firefox',
-        prefs: {
-          'dom.w3c_touch_events.enabled': 1,
-        },
-      },
-    },
+    // customLaunchers: {
+    //   TouchyFirefox: {
+    //     base: 'Firefox',
+    //     prefs: {
+    //       'dom.w3c_touch_events.enabled': 1,
+    //     },
+    //   },
+    // },
   });
 };


### PR DESCRIPTION
This workflow simplifies releasing process. The previous way of doing it involved:
1. Running tests **outside** release process. This could have lead to mistakes.
2. Updating version in `projects/gallery` by hand
3. Committing & pushing that change
4. Possibly waiting for the tests to finish
5. Running `npm upload` script by hand.
6. Creating GH release after the fact, not as a trigger.

This is now simplified since the process looks like this: 
1. Publish GH release
and that's it!

The release triggers following steps in one GH workflow:
1. Build & test
2. Updates `npm version`
3. Publishes the package to NPM registry